### PR TITLE
add support for auto-refreshing bntx images in-place

### DIFF
--- a/auto-refresh-server/src/bntx.rs
+++ b/auto-refresh-server/src/bntx.rs
@@ -53,8 +53,8 @@ pub fn handle_file_replace(hash: Hash40, replace: &[u8]) -> bool {
                 )
             };
             if let Some(loaded_image_size) = check_size(loaded_image_slice, replace) {
-                loaded_image_slice[0x1000..loaded_image_size]
-                    .copy_from_slice(&replace[0x1000..loaded_image_size]);
+                loaded_image_slice[0x1000..loaded_image_size + 0x1000]
+                    .copy_from_slice(&replace[0x1000..loaded_image_size + 0x1000]);
                 return true;
             }
             println!("[auto-refresh] Bntx file: {:#X} does not match loaded size, so the refresh request was rejected.", hash.as_u64());

--- a/auto-refresh-server/src/bntx.rs
+++ b/auto-refresh-server/src/bntx.rs
@@ -1,0 +1,123 @@
+use skyline::hooks::InlineCtx;
+use skyline::{hook, install_hooks};
+use smash_arc::*;
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::ffi::CStr;
+use std::sync::Mutex;
+
+use crate::resource;
+
+struct HelperThreadedFileInfo {
+    is_loaded: bool,
+    data_ptr: u64,
+    decompressed_size: usize,
+}
+
+#[repr(packed)]
+struct ThreadedFileLoad {
+    file_path_index: u32,
+    padding: u32,
+    data_ptr: *mut u8,
+    decompressed_size: usize,
+    // and more...
+}
+
+lazy_static! {
+    static ref THREADED_FILES: Mutex<HashMap<u64, HelperThreadedFileInfo>> = {
+        let m = HashMap::new();
+        Mutex::new(m)
+    };
+}
+
+fn check_size(loaded_bntx: &[u8], replace: &[u8]) -> Option<usize> {
+    if loaded_bntx.len() > 0x1000 && replace.len() > 0x1000 {
+        let loaded_image_size =
+            usize::from_le_bytes(loaded_bntx[0xFF8..0x1000].try_into().unwrap());
+        let replace_image_size = usize::from_le_bytes(replace[0xFF8..0x1000].try_into().unwrap());
+        if loaded_image_size == replace_image_size {
+            return Some(loaded_image_size);
+        }
+        return None;
+    }
+    return None;
+}
+
+pub fn handle_file_replace(hash: Hash40, replace: &[u8]) -> bool {
+    let map = THREADED_FILES.lock().unwrap();
+    if map.contains_key(&hash.as_u64()) {
+        let loaded_image = map.get(&hash.as_u64()).unwrap();
+        if loaded_image.is_loaded {
+            let loaded_image_slice = unsafe {
+                std::slice::from_raw_parts_mut(
+                    loaded_image.data_ptr as *mut u8,
+                    loaded_image.decompressed_size,
+                )
+            };
+            if let Some(loaded_image_size) = check_size(loaded_image_slice, replace) {
+                loaded_image_slice[0x1000..loaded_image_size]
+                    .copy_from_slice(&replace[0x1000..loaded_image_size]);
+                return true;
+            }
+            println!("[auto-refresh] Bntx file: {:#X} does not match loaded size, so the refresh request was rejected.", hash.as_u64());
+            return false;
+        }
+    }
+
+    println!(
+        "[auto-refresh] Bntx file: {:#X} is not currently loaded.",
+        hash.as_u64()
+    );
+
+    return false;
+}
+
+#[hook(offset = 0x37a17ac, inline)]
+unsafe fn load_files_threaded_hook(ctx: &mut InlineCtx) {
+    let threaded_load = (*ctx.registers[19].x.as_ref() as *mut ThreadedFileLoad);
+
+    let file_path_index = (*threaded_load).file_path_index as usize;
+
+    let arc = resource::arc();
+
+    if file_path_index < arc.get_file_paths().len() {
+        let file_path = &arc.get_file_paths()[file_path_index];
+        let path_hash = file_path.path.hash40();
+
+        let decompressed_size = (*threaded_load).decompressed_size;
+
+        THREADED_FILES.lock().unwrap().insert(
+            path_hash.as_u64(),
+            HelperThreadedFileInfo {
+                is_loaded: true,
+                data_ptr: (*threaded_load).data_ptr as u64,
+                decompressed_size: decompressed_size,
+            },
+        );
+    }
+}
+
+#[hook(offset = 0x37a1470, inline)]
+unsafe fn free_files_threaded_hook(ctx: &mut InlineCtx) {
+    let threaded_load = (*ctx.registers[0].x.as_ref() as *mut ThreadedFileLoad);
+
+    let file_path_index = (*threaded_load).file_path_index as usize;
+
+    let arc = resource::arc();
+
+    if file_path_index < arc.get_file_paths().len() {
+        let file_path = &arc.get_file_paths()[file_path_index];
+        let path_hash = file_path.path.hash40();
+
+        let mut map = THREADED_FILES.lock().unwrap();
+
+        if map.contains_key(&path_hash.as_u64()) {
+            map.entry(path_hash.as_u64())
+                .and_modify(|helper| (*helper).is_loaded = false);
+        }
+    }
+}
+
+pub fn install() {
+    install_hooks!(load_files_threaded_hook, free_files_threaded_hook);
+}

--- a/auto-refresh-server/src/ffi.rs
+++ b/auto-refresh-server/src/ffi.rs
@@ -1,0 +1,37 @@
+use smash_arc::*;
+
+#[no_mangle]
+unsafe extern "C" fn auto_refresh_bntx(hash: u64, replace: *mut u8, size: usize) -> bool {
+    let slice = std::slice::from_raw_parts_mut(replace, size);
+    crate::bntx::handle_file_replace(Hash40::from(hash), slice)
+}
+
+#[no_mangle]
+unsafe extern "C" fn auto_refresh_file(hash: u64, replace: *mut u8, size: usize) -> bool {
+    let is_loaded = arcropolis_api::is_file_loaded(hash);
+    if is_loaded {
+        let fs = crate::resource::filesystem_info();
+        let loaded_arc = &fs.path_info.arc;
+
+        let file_info = loaded_arc
+            .get_file_info_from_hash(Hash40::from(hash))
+            .unwrap();
+        let loaded_data = &fs.get_loaded_datas()[file_info.file_info_indice_index.0 as usize];
+
+        if !loaded_data.data.is_null() {
+            let decompressed_size = loaded_arc
+                .get_file_data(file_info, Region::UsEnglish)
+                .decomp_size;
+            let slice = std::slice::from_raw_parts_mut(
+                loaded_data.data as *mut u8,
+                decompressed_size as usize,
+            );
+            let replace_slice = std::slice::from_raw_parts_mut(replace, size);
+            slice.copy_from_slice(replace_slice);
+
+            return true;
+        }
+        return false;
+    }
+    return false;
+}

--- a/auto-refresh-server/src/lib.rs
+++ b/auto-refresh-server/src/lib.rs
@@ -12,9 +12,6 @@ use std::path::Path;
 use std::sync::Mutex;
 use std::thread;
 
-#[macro_use]
-extern crate lazy_static;
-
 mod bntx;
 mod ffi;
 mod offsets;

--- a/auto-refresh-server/src/lib.rs
+++ b/auto-refresh-server/src/lib.rs
@@ -126,7 +126,7 @@ pub fn scan_path_for_files(path: &Path) {
 }
 
 #[skyline::main(name = "auto-refresh")]
-pub unsafe fn main() {
+pub fn main() {
     bntx::install();
 
     scan_path_for_files(Path::new(SCAN_DIR));

--- a/auto-refresh-server/src/lib.rs
+++ b/auto-refresh-server/src/lib.rs
@@ -2,7 +2,7 @@
 
 use once_cell::sync::Lazy;
 use skyline::hooks::InlineCtx;
-use skyline::{hook, install_hooks};
+use skyline::{hook, install_hook};
 use smash_arc::*;
 use std::collections::HashMap;
 use std::io::{Cursor, Read, Write};
@@ -12,6 +12,11 @@ use std::path::Path;
 use std::sync::Mutex;
 use std::thread;
 
+#[macro_use]
+extern crate lazy_static;
+
+mod bntx;
+mod ffi;
 mod offsets;
 mod resource;
 
@@ -23,26 +28,35 @@ static mut FILES_INFO: Lazy<Vec<String>> = Lazy::new(|| vec![]);
 pub fn refresh_file(path: &String) {
     unsafe {
         let file_hash = smash_arc::hash40(&path.to_owned());
-        let is_loaded = arcropolis_api::is_file_loaded(file_hash.as_u64());
+        if path.ends_with("bntx") {
+            if let Ok(data) = std::fs::read(Path::new(SCAN_DIR).join(path)) {
+                bntx::handle_file_replace(file_hash, &data);
+            }
+        } else {
+            let is_loaded = arcropolis_api::is_file_loaded(file_hash.as_u64());
+            println!("[auto-refresh] Updating file contents...");
+            if is_loaded {
+                let fs = resource::filesystem_info();
+                let loaded_arc = &fs.path_info.arc;
 
-        if is_loaded {
-            let fs = resource::filesystem_info();
-            let loaded_arc = &fs.path_info.arc;
+                let file_info = loaded_arc.get_file_info_from_hash(file_hash).unwrap();
+                let loaded_data =
+                    &fs.get_loaded_datas()[file_info.file_info_indice_index.0 as usize];
 
-            let file_info = loaded_arc.get_file_info_from_hash(file_hash).unwrap();
-            let loaded_data = &fs.get_loaded_datas()[file_info.file_info_indice_index.0 as usize];
-
-            let decompressed_size = loaded_arc
-                .get_file_data(file_info, Region::UsEnglish)
-                .decomp_size;
-            let slice = std::slice::from_raw_parts_mut(
-                loaded_data.data as *mut u8,
-                decompressed_size as usize,
-            );
-
-            match std::fs::read(Path::new(SCAN_DIR).join(path)) {
-                Ok(data) => slice.copy_from_slice(&data),
-                Err(err) => println!("[auto-refresh] Error: {:?}", err),
+                if !loaded_data.data.is_null() {
+                    let decompressed_size = loaded_arc
+                        .get_file_data(file_info, Region::UsEnglish)
+                        .decomp_size;
+                    let slice = std::slice::from_raw_parts_mut(
+                        loaded_data.data as *mut u8,
+                        decompressed_size as usize,
+                    );
+                    println!("[auto-refresh] Overwriting buffer...");
+                    match std::fs::read(Path::new(SCAN_DIR).join(path)) {
+                        Ok(data) => slice.copy_from_slice(&data),
+                        Err(err) => println!("[auto-refresh] Error: {:?}", err),
+                    }
+                }
             }
         }
     }
@@ -63,7 +77,7 @@ pub fn handle_buffer(mut stream: TcpStream) {
             let data = String::from_utf8_lossy(&buffer[0..size]).into_owned();
             let data = data.trim();
             let mut response: String = "Refreshed!".to_string();
-            println!("{}", data);    
+            println!("{}", data);
             let lines: Vec<&str> = data.split("\n").collect();
             if lines.len() >= 1 {
                 for line in lines.iter() {
@@ -72,14 +86,14 @@ pub fn handle_buffer(mut stream: TcpStream) {
             } else {
                 refresh_files();
             }
-        
+
             match stream.write(response.as_bytes()) {
-                Ok(_ok) => {},
+                Ok(_ok) => {}
                 Err(err) => {
                     println!("[auto-refresh] Stream Write Error: {:?}", err);
                 }
             }
-        },
+        }
         Err(err) => {
             println!("[auto-refresh] Network Error: {:?}", err);
             stream.flush().unwrap();
@@ -112,7 +126,9 @@ pub fn scan_path_for_files(path: &Path) {
 }
 
 #[skyline::main(name = "auto-refresh")]
-pub fn main() {
+pub unsafe fn main() {
+    bntx::install();
+
     scan_path_for_files(Path::new(SCAN_DIR));
 
     thread::spawn(|| {

--- a/auto-refresh-server/src/offsets.rs
+++ b/auto-refresh-server/src/offsets.rs
@@ -1,18 +1,20 @@
 use once_cell::sync::Lazy;
 use skyline::hooks::{getRegionAddress, Region};
 
-static OFFSETS: Lazy<Offsets> = Lazy::new(|| {
-    Offsets::new()
-});
+static OFFSETS: Lazy<Offsets> = Lazy::new(|| Offsets::new());
 
-static FILESYSTEM_INFO_ADRP_SEARCH_CODE: &[u8] = &[0xf3, 0x03, 0x00, 0xaa, 0x1f, 0x01, 0x09, 0x6b, 0xe0, 0x04, 0x00, 0x54];
+static FILESYSTEM_INFO_ADRP_SEARCH_CODE: &[u8] = &[
+    0xf3, 0x03, 0x00, 0xaa, 0x1f, 0x01, 0x09, 0x6b, 0xe0, 0x04, 0x00, 0x54,
+];
 
 static RES_SERVICE_ADRP_SEARCH_CODE: &[u8] = &[
     0x04, 0x01, 0x49, 0xfa, 0x21, 0x05, 0x00, 0x54, 0x5f, 0x00, 0x00, 0xf9, 0x7f, 0x00, 0x00, 0xf9,
 ];
 
 fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack.windows(needle.len()).position(|window| window == needle)
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
 }
 
 #[allow(clippy::inconsistent_digit_grouping)]
@@ -59,13 +61,17 @@ impl Offsets {
         let text = get_text();
 
         let filesystem_info = {
-            let adrp = find_subsequence(text, FILESYSTEM_INFO_ADRP_SEARCH_CODE).expect("Unable to find subsequence") + 12;
+            let adrp = find_subsequence(text, FILESYSTEM_INFO_ADRP_SEARCH_CODE)
+                .expect("Unable to find subsequence")
+                + 12;
             let adrp_offset = offset_from_adrp(adrp);
             let ldr_offset = offset_from_ldr(adrp + 4);
             adrp_offset + ldr_offset
         };
         let res_service = {
-            let adrp = find_subsequence(text, RES_SERVICE_ADRP_SEARCH_CODE).expect("Unable to find subsequence") + 16;
+            let adrp = find_subsequence(text, RES_SERVICE_ADRP_SEARCH_CODE)
+                .expect("Unable to find subsequence")
+                + 16;
             let adrp_offset = offset_from_adrp(adrp);
             let ldr_offset = offset_from_ldr(adrp + 4);
             adrp_offset + ldr_offset

--- a/auto-refresh-server/src/resource.rs
+++ b/auto-refresh-server/src/resource.rs
@@ -8,7 +8,9 @@ pub use types::*;
 use crate::offsets;
 
 fn offset_to_addr<T>(offset: usize) -> *mut T {
-    unsafe { (skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as usize + offset) as *mut T }
+    unsafe {
+        (skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as usize + offset) as *mut T
+    }
 }
 
 pub fn filesystem_info() -> &'static FilesystemInfo {

--- a/auto-refresh-server/src/resource/containers.rs
+++ b/auto-refresh-server/src/resource/containers.rs
@@ -16,7 +16,8 @@ impl<T> CppVector<T> {
     unsafe fn realloc(&mut self) {
         let current_capacity = self.eos.offset_from(self.start) as usize;
         let current_len = self.end.offset_from(self.start) as usize;
-        let layout = Layout::from_size_align(current_capacity * 2 * std::mem::size_of::<T>(), 1).unwrap();
+        let layout =
+            Layout::from_size_align(current_capacity * 2 * std::mem::size_of::<T>(), 1).unwrap();
         let (new_start, new_eos) = {
             let start = std::alloc::alloc(layout) as *mut T;
             (start, start.add(current_capacity * 2))
@@ -45,7 +46,11 @@ impl<T> CppVector<T> {
             let start = std::alloc::alloc(layout) as *mut T;
             (start, start.add(cap))
         };
-        Self { start, end: start, eos }
+        Self {
+            start,
+            end: start,
+            eos,
+        }
     }
 
     pub fn push(&mut self, val: T) {
@@ -125,7 +130,11 @@ impl<T: Copy + Clone> CppVector<T> {
         };
         let new_slice = unsafe { std::slice::from_raw_parts_mut(start, slice.len()) };
         new_slice.copy_from_slice(slice);
-        Self { start, end: eos, eos }
+        Self {
+            start,
+            end: eos,
+            eos,
+        }
     }
 }
 
@@ -162,7 +171,10 @@ impl<'a, T> IntoIterator for &'a CppVector<T> {
     type Item = &'a T;
 
     fn into_iter(self) -> Self::IntoIter {
-        CppVectorIterator { vector: self, index: 0 }
+        CppVectorIterator {
+            vector: self,
+            index: 0,
+        }
     }
 }
 
@@ -171,7 +183,10 @@ impl<'a, T> IntoIterator for &'a mut CppVector<T> {
     type Item = &'a mut T;
 
     fn into_iter(self) -> Self::IntoIter {
-        CppVectorIteratorMut { vector: self, index: 0 }
+        CppVectorIteratorMut {
+            vector: self,
+            index: 0,
+        }
     }
 }
 
@@ -187,7 +202,9 @@ impl<'a, T> Iterator for CppVectorIterator<'a, T> {
         unsafe {
             if self.vector.start.offset(self.index) != self.vector.end {
                 self.index += 1;
-                Some(std::mem::transmute::<*mut T, &'a T>(self.vector.start.offset(self.index - 1)))
+                Some(std::mem::transmute::<*mut T, &'a T>(
+                    self.vector.start.offset(self.index - 1),
+                ))
             } else {
                 None
             }
@@ -207,7 +224,9 @@ impl<'a, T> Iterator for CppVectorIteratorMut<'a, T> {
         unsafe {
             if self.vector.start.offset(self.index) != self.vector.end {
                 self.index += 1;
-                Some(std::mem::transmute::<*mut T, &'a mut T>(self.vector.start.offset(self.index - 1)))
+                Some(std::mem::transmute::<*mut T, &'a mut T>(
+                    self.vector.start.offset(self.index - 1),
+                ))
             } else {
                 None
             }
@@ -244,7 +263,10 @@ impl<'a> IntoIterator for &'a ResList {
     type Item = &'a LoadInfo;
 
     fn into_iter(self) -> Self::IntoIter {
-        ResListIter { list: self, count: 0 }
+        ResListIter {
+            list: self,
+            count: 0,
+        }
     }
 }
 
@@ -253,7 +275,10 @@ impl<'a> IntoIterator for &'a mut ResList {
     type Item = &'a mut LoadInfo;
 
     fn into_iter(self) -> Self::IntoIter {
-        ResListIterMut { list: self, count: 0 }
+        ResListIterMut {
+            list: self,
+            count: 0,
+        }
     }
 }
 
@@ -279,7 +304,10 @@ impl ResList {
     }
 
     pub fn node_iter(&self) -> NodeIter {
-        NodeIter { list: self, count: 0 }
+        NodeIter {
+            list: self,
+            count: 0,
+        }
     }
 
     pub fn len(&self) -> usize {

--- a/auto-refresh-server/src/resource/types.rs
+++ b/auto-refresh-server/src/resource/types.rs
@@ -79,7 +79,9 @@ pub struct FilesystemInfo {
 
 impl FilesystemInfo {
     pub fn get_loaded_filepaths(&self) -> &[LoadedFilepath] {
-        unsafe { std::slice::from_raw_parts(self.loaded_filepaths, self.loaded_filepath_len as usize) }
+        unsafe {
+            std::slice::from_raw_parts(self.loaded_filepaths, self.loaded_filepath_len as usize)
+        }
     }
 
     pub fn get_loaded_datas(&self) -> &[LoadedData] {
@@ -87,7 +89,9 @@ impl FilesystemInfo {
     }
 
     pub fn get_loaded_directories(&self) -> &[LoadedDirectory] {
-        unsafe { std::slice::from_raw_parts(self.loaded_directories, self.loaded_directory_len as usize) }
+        unsafe {
+            std::slice::from_raw_parts(self.loaded_directories, self.loaded_directory_len as usize)
+        }
     }
 }
 


### PR DESCRIPTION
When the game loads a BNTX file, it copies its contents to a new buffer so as to not modify the loaded contents in the main resource service. This pull request currently adds two inline hooks that intercept the game's ``load_files_threaded`` function to track when BNTX images are loaded and unloaded.

Other changes:

- A barebones C API was also added for plugin developers, allowing other plugins to modify both regular and BNTX files at runtime.
- ``cargo fmt`` was ran.

I'm marking this as a draft as I am not sure about the implementation here; it's messy and needs more testing before it can be merged.